### PR TITLE
delete has_many :songs

### DIFF
--- a/db/migrate/20190807043729_devise_create_users.rb
+++ b/db/migrate/20190807043729_devise_create_users.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class DeviseCreateUsers < ActiveRecord::Migration[5.2]
-  has_many :songs
-  
+class DeviseCreateUsers < ActiveRecord::Migration[5.2]  
   def change
     create_table :users do |t|
       ## Database authenticatable


### PR DESCRIPTION
## 説明
- migrationファイル、create_devise_user.rb に不要な記述があってエラーが出てたので修正しました。